### PR TITLE
add argument to explicitly disable buffer aliasing

### DIFF
--- a/01b-BoringMixer/BoringMixer.cpp
+++ b/01b-BoringMixer/BoringMixer.cpp
@@ -43,6 +43,6 @@ PluginLoad(BoringMixer2UGens) {
     ft = inTable;
     // registerUnit takes the place of the Define*Unit functions. It automatically checks for the presence of a
     // destructor function.
-    // However, it does not seem to be possible to disable buffer aliasing with the C++ header.
-    registerUnit<BoringMixer2>(ft, "BoringMixer2");
+    // starting from version 3.11 it also allows to disable buffer aliasing
+    registerUnit<BoringMixer2>(ft, "BoringMixer2", false);
 }

--- a/02b-MySaw/MySaw.cpp
+++ b/02b-MySaw/MySaw.cpp
@@ -131,6 +131,6 @@ PluginLoad(MySawUGens)
 
     // registerUnit takes the place of the Define*Unit functions. It automatically checks for the presence of a
     // destructor function.
-    // However, it does not seem to be possible to disable buffer aliasing with the C++ header.
-    registerUnit<MySaw>(ft, "MySaw");
+    // starting from version 3.11 it also allows to disable buffer aliasing
+    registerUnit<MySaw>(ft, "MySaw", false);
 }

--- a/02b-MySaw/MySaw2.cpp
+++ b/02b-MySaw/MySaw2.cpp
@@ -131,6 +131,6 @@ PluginLoad(MySaw2UGens)
 
     // registerUnit takes the place of the Define*Unit functions. It automatically checks for the presence of a
     // destructor function.
-    // However, it does not seem to be possible to disable buffer aliasing with the C++ header.
-    registerUnit<MySaw2>(ft, "MySaw2");
+    // starting from version 3.11 it also allows to disable buffer aliasing
+    registerUnit<MySaw2>(ft, "MySaw2", false);
 }


### PR DESCRIPTION
Now that https://github.com/supercollider/supercollider/pull/4356 is in, this can be added to the examples.

However, should we wait till 3.11 to merge this?